### PR TITLE
issues/30: all task invocations should have unique task_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## `wiji` changelog:
 most recent version is listed first.
 
+## **version:** v0.1.3
+- all task invocations should have unique task_id: https://github.com/komuw/wiji/pull/32
 
 ## **version:** v0.1.2
 - first release

--- a/examples/example_tasks.py
+++ b/examples/example_tasks.py
@@ -1,9 +1,7 @@
 import asyncio
-import functools
-import concurrent
-
 
 import wiji
+
 from examples.redis_broker import ExampleRedisBroker
 
 MY_BROKER = ExampleRedisBroker()  # wiji.broker.SimpleBroker()

--- a/examples/example_tasks.py
+++ b/examples/example_tasks.py
@@ -4,7 +4,9 @@ import concurrent
 
 
 import wiji
-import redis
+from examples.redis_broker import ExampleRedisBroker
+
+MY_BROKER = ExampleRedisBroker()  # wiji.broker.SimpleBroker()
 
 
 def BLOCKING_DISK_IO(the_broker) -> wiji.task.Task:
@@ -128,70 +130,6 @@ def exception_task(the_broker, chain=None) -> wiji.task.Task:
     return task
 
 
-class ExampleRedisBroker(wiji.broker.BaseBroker):
-    """
-    use redis as our queue.
-    This implements a basic FIFO queue using redis.
-    Basically we use the redis command LPUSH to push messages onto the queue and BRPOP to pull them off.
-    https://redis.io/commands/lpush
-    https://redis.io/commands/brpop
-    Note that in practice, you would probaly want to use a non-blocking redis
-    client eg https://github.com/aio-libs/aioredis
-    This example uses concurrent.futures.ThreadPoolExecutor to workaround
-    the fact that we are using a blocking/sync redis client.
-    Use an async client in real life/code.
-    """
-
-    def __init__(self):
-        self.redis_instance = redis.StrictRedis(host="localhost", port=6379, db=0)
-
-    async def check(self, queue_name: str) -> None:
-        await asyncio.sleep(1 / 117)
-        pass
-
-    async def enqueue(self, item: str, queue_name: str, task_options) -> None:
-        try:
-            self.loop = asyncio.get_running_loop()
-        except RuntimeError:
-            self.loop = asyncio.get_event_loop()
-
-        with concurrent.futures.ThreadPoolExecutor(
-            thread_name_prefix="wiji-redis-thread-pool"
-        ) as executor:
-            await self.loop.run_in_executor(
-                executor, functools.partial(self.blocking_enqueue, queue_name=queue_name, item=item)
-            )
-
-    def blocking_enqueue(self, queue_name, item):
-        self.redis_instance.lpush(queue_name, item)
-
-    async def dequeue(self, queue_name: str) -> str:
-        try:
-            self.loop = asyncio.get_running_loop()
-        except RuntimeError:
-            self.loop = asyncio.get_event_loop()
-
-        with concurrent.futures.ThreadPoolExecutor(
-            thread_name_prefix="wiji-redis-thread-pool"
-        ) as executor:
-            while True:
-                item = await self.loop.run_in_executor(
-                    executor, functools.partial(self.blocking_dequeue, queue_name=queue_name)
-                )
-                if item:
-                    return item
-                else:
-                    await asyncio.sleep(5)
-
-    def blocking_dequeue(self, queue_name: str):
-        dequed_item = self.redis_instance.brpop(queue_name, timeout=3)
-        if not dequed_item:
-            return None
-        dequed_item = dequed_item[1]
-        return dequed_item
-
-
-MY_BROKER = ExampleRedisBroker()  # wiji.broker.SimpleBroker()
 ###############################################################################################
 
 # 1. publish task

--- a/examples/redis_broker.py
+++ b/examples/redis_broker.py
@@ -48,10 +48,11 @@ class ExampleRedisBroker(wiji.broker.BaseBroker):
             thread_name_prefix="wiji-redis-thread-pool"
         ) as executor:
             await self.loop.run_in_executor(
-                executor, functools.partial(self.blocking_enqueue, queue_name=queue_name, item=item)
+                executor,
+                functools.partial(self._blocking_enqueue, queue_name=queue_name, item=item),
             )
 
-    def blocking_enqueue(self, queue_name, item):
+    def _blocking_enqueue(self, queue_name, item):
         self.redis_instance.lpush(queue_name, item)
 
     async def dequeue(self, queue_name: str) -> str:
@@ -65,14 +66,14 @@ class ExampleRedisBroker(wiji.broker.BaseBroker):
         ) as executor:
             while True:
                 item = await self.loop.run_in_executor(
-                    executor, functools.partial(self.blocking_dequeue, queue_name=queue_name)
+                    executor, functools.partial(self._blocking_dequeue, queue_name=queue_name)
                 )
                 if item:
                     return item
                 else:
                     await asyncio.sleep(1 / 117)
 
-    def blocking_dequeue(self, queue_name: str):
+    def _blocking_dequeue(self, queue_name: str):
         dequed_item = self.redis_instance.brpop(queue_name, timeout=3)
         if not dequed_item:
             return None

--- a/examples/redis_broker.py
+++ b/examples/redis_broker.py
@@ -10,6 +10,10 @@ import redis
 
 class ExampleRedisBroker(wiji.broker.BaseBroker):
     """
+    DO NOT USE THIS IN PRODUCTION.
+    It will fail you, this is only used for adhoc testing
+    and for showing how easy it is to implement your own broker satisfying `wiji.broker.BaseBroker`
+
     use redis as our queue.
     This implements a basic FIFO queue using redis.
     Basically we use the redis command LPUSH to push messages onto the queue and BRPOP to pull them off.

--- a/examples/redis_broker.py
+++ b/examples/redis_broker.py
@@ -1,0 +1,85 @@
+import os
+import asyncio
+import functools
+import concurrent
+
+
+import wiji
+import redis
+
+
+class ExampleRedisBroker(wiji.broker.BaseBroker):
+    """
+    use redis as our queue.
+    This implements a basic FIFO queue using redis.
+    Basically we use the redis command LPUSH to push messages onto the queue and BRPOP to pull them off.
+    https://redis.io/commands/lpush
+    https://redis.io/commands/brpop
+    Note that in practice, you would probaly want to use a non-blocking redis
+    client eg https://github.com/aio-libs/aioredis
+    This example uses concurrent.futures.ThreadPoolExecutor to workaround
+    the fact that we are using a blocking/sync redis client.
+    Use an async client in real life/code.
+    """
+
+    def __init__(self):
+        host = "localhost"
+        port = 6379
+        if os.environ.get("IN_DOCKER"):
+            host = os.environ["REDIS_HOST"]
+            port = os.environ["REDIS_PORT"]
+
+        self.redis_instance = redis.StrictRedis(host=host, port=port, db=0)
+
+    async def check(self, queue_name: str) -> None:
+        await asyncio.sleep(1 / 117)
+
+    async def enqueue(self, item: str, queue_name: str, task_options) -> None:
+        try:
+            self.loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self.loop = asyncio.get_event_loop()
+
+        with concurrent.futures.ThreadPoolExecutor(
+            thread_name_prefix="wiji-redis-thread-pool"
+        ) as executor:
+            await self.loop.run_in_executor(
+                executor, functools.partial(self.blocking_enqueue, queue_name=queue_name, item=item)
+            )
+
+    def blocking_enqueue(self, queue_name, item):
+        self.redis_instance.lpush(queue_name, item)
+
+    async def dequeue(self, queue_name: str) -> str:
+        try:
+            self.loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self.loop = asyncio.get_event_loop()
+
+        with concurrent.futures.ThreadPoolExecutor(
+            thread_name_prefix="wiji-redis-thread-pool"
+        ) as executor:
+            while True:
+                item = await self.loop.run_in_executor(
+                    executor, functools.partial(self.blocking_dequeue, queue_name=queue_name)
+                )
+                if item:
+                    return item
+                else:
+                    await asyncio.sleep(1 / 117)
+
+    def blocking_dequeue(self, queue_name: str):
+        dequed_item = self.redis_instance.brpop(queue_name, timeout=3)
+        if not dequed_item:
+            return None
+        dequed_item = dequed_item[1]
+        return dequed_item
+
+    async def done(
+        self,
+        item: str,
+        queue_name: str,
+        task_options: wiji.task.TaskOptions,
+        state: wiji.task.TaskState,
+    ) -> None:
+        pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from unittest import TestCase, mock
 
 import cli
 
-logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.DEBUG)
+logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.CRITICAL)
 
 
 class MockArgumentParser:

--- a/tests/test_hook.py
+++ b/tests/test_hook.py
@@ -6,7 +6,7 @@ from unittest import TestCase, mock
 import wiji
 
 
-logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.DEBUG)
+logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.CRITICAL)
 
 
 def AsyncMock(*args, **kwargs):

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -7,7 +7,7 @@ from unittest import TestCase, mock
 import wiji
 
 
-logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.DEBUG)
+logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.CRITICAL)
 
 
 def AsyncMock(*args, **kwargs):

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -7,7 +7,7 @@ from unittest import TestCase, mock
 import wiji
 
 
-logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.DEBUG)
+logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.CRITICAL)
 
 
 def AsyncMock(*args, **kwargs):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -9,7 +9,7 @@ from unittest import TestCase, mock
 import wiji
 
 
-logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.DEBUG)
+logging.basicConfig(format="%(message)s", stream=sys.stdout, level=logging.CRITICAL)
 
 
 def AsyncMock(*args, **kwargs):

--- a/wiji/__version__.py
+++ b/wiji/__version__.py
@@ -2,7 +2,7 @@ about = {
     "__title__": "wiji",
     "__description__": "Wiji is an asyncio distributed task processor/queue.",
     "__url__": "https://github.com/komuw/wiji",
-    "__version__": "v0.1.2",
+    "__version__": "v0.1.3",
     "__author__": "komuW",
     "__author_email__": "komuw05@gmail.com",
     "__license__": "MIT",

--- a/wiji/task.py
+++ b/wiji/task.py
@@ -426,7 +426,7 @@ class Task(abc.ABC):
             await self._broker_check(from_worker=False)
 
         # every invocation of `my_task.delay()` is counted as unique and
-        # should have a unique task_id even it is a retry of a previous request
+        # should have a unique task_id even if it is a retry of a previous request
         self.task_options.task_id = str(uuid.uuid4())
         proto = protocol.Protocol(
             version=1,

--- a/wiji/task.py
+++ b/wiji/task.py
@@ -1,8 +1,6 @@
 import abc
 import enum
 import uuid
-import random
-import string
 import typing
 import asyncio
 import logging

--- a/wiji/task.py
+++ b/wiji/task.py
@@ -90,7 +90,7 @@ class TaskOptions:
         else:
             self.hook_metadata = ""
 
-        self.task_id: typing.Union[None, str] = None
+        self.task_id: str = ""
 
         # `drain_duration` is the duration(in seconds) that a worker should wait
         # after getting a termination signal(SIGTERM, SIGQUIT etc).


### PR DESCRIPTION
Thank you for contributing to wiji.                    
Every contribution to wiji is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to wiji, and wiji agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that wiji shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- every invocation of `my_task.delay()` should be counted as unique and
    should have a unique `task_id` even if it is a retry of a previous request

# Why(Why did you change it?)
- fixes: https://github.com/komuw/wiji/issues/30

# References:
1. 
