### PR TITLE
issues/33: wiji.broker.BaseBroker interface should have a method that is called during shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## `wiji` changelog:
 most recent version is listed first.
 
+## **version:** v0.1.4
+- `wiji.broker.BaseBroker` interface should have a method that is called during shutdown
+  and `wiji.Worker` calls this method when it receives a shutdown signal like `SIGTERM`: https://github.com/komuw/wiji/pull/34
+
 ## **version:** v0.1.3
 - all task invocations should have unique task_id: https://github.com/komuw/wiji/pull/32
 

--- a/wiji/__version__.py
+++ b/wiji/__version__.py
@@ -2,7 +2,7 @@ about = {
     "__title__": "wiji",
     "__description__": "Wiji is an asyncio distributed task processor/queue.",
     "__url__": "https://github.com/komuw/wiji",
-    "__version__": "v0.1.3",
+    "__version__": "v0.1.4",
     "__author__": "komuW",
     "__author_email__": "komuw05@gmail.com",
     "__license__": "MIT",

--- a/wiji/broker.py
+++ b/wiji/broker.py
@@ -58,6 +58,18 @@ class BaseBroker(abc.ABC):
         """
         raise NotImplementedError("`done` method must be implemented.")
 
+    @abc.abstractmethod
+    async def shutdown(self, queue_name: str, duration: int) -> None:
+        """
+        called by wiji worker when it receives a shutdown signal like `SIGTERM`.
+        the broker can decide to perform shutdown procedures like releasing connections/file descriptors etc.
+
+        Parameters:
+            queue_name: name of queue which the wiji worker was consuming from
+            duration: duration in seconds that wiji worker will wait for after calling this method.
+        """
+        raise NotImplementedError("`shutdown` method must be implemented.")
+
 
 class InMemoryBroker(BaseBroker):
     """
@@ -113,3 +125,6 @@ class InMemoryBroker(BaseBroker):
             return await asyncio.sleep(delay=-1, result=None)
         else:
             raise ValueError("queue with name: {0} does not exist.".format(queue_name))
+
+    async def shutdown(self, queue_name: str, duration: int) -> None:
+        return await asyncio.sleep(delay=-1, result=None)

--- a/wiji/broker.py
+++ b/wiji/broker.py
@@ -59,7 +59,7 @@ class BaseBroker(abc.ABC):
         raise NotImplementedError("`done` method must be implemented.")
 
     @abc.abstractmethod
-    async def shutdown(self, queue_name: str, duration: int) -> None:
+    async def shutdown(self, queue_name: str, duration: float) -> None:
         """
         called by wiji worker when it receives a shutdown signal like `SIGTERM`.
         the broker can decide to perform shutdown procedures like releasing connections/file descriptors etc.
@@ -126,5 +126,5 @@ class InMemoryBroker(BaseBroker):
         else:
             raise ValueError("queue with name: {0} does not exist.".format(queue_name))
 
-    async def shutdown(self, queue_name: str, duration: int) -> None:
+    async def shutdown(self, queue_name: str, duration: float) -> None:
         return await asyncio.sleep(delay=-1, result=None)


### PR DESCRIPTION
Thank you for contributing to wiji.                    
Every contribution to wiji is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to wiji, and wiji agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that wiji shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- wiji.broker.BaseBroker interface should have a method that is called during shutdown

# Why(Why did you change it?)
- fixes: https://github.com/komuw/wiji/issues/33

# References:
1. 
