### PR TITLE
issues/43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ most recent version is listed first.
 - bugfix, `task.task_options is stale`    
   We had a case where `broker.done` would get called with `task_id`==`''`(empty string) : https://github.com/komuw/wiji/pull/39
 - add timestamp to log events: https://github.com/komuw/wiji/pull/45
+- remove `wiji.task.WijiRetryError`.   
+  we replace it with a `wiji.task.Task._RETRYING` boolean.: https://github.com/komuw/wiji/pull/46
 
 ## **version:** v0.1.5
 - fix examples broker which was broken by last PR: https://github.com/komuw/wiji/pull/35

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -177,47 +177,39 @@ class TestTask(TestCase):
         with mock.patch("wiji.broker.InMemoryBroker.enqueue", new=AsyncMock()) as mock_enqueue:
             all_task_ids = []
 
-            self._run(self.my_task.delay(a=44, b=252223))
+            self._run(self.my_task.delay(a=44, b=252_223))
             self.assertTrue(mock_enqueue.mock.called)
             task_id1 = json.loads(mock_enqueue.mock.call_args[1]["item"])["task_options"]["task_id"]
             all_task_ids.append(task_id1)
 
-            self._run(self.my_task.delay(a=44, b=252223))
+            self._run(self.my_task.delay(a=44, b=252_223))
             task_id2 = json.loads(mock_enqueue.mock.call_args[1]["item"])["task_options"]["task_id"]
             all_task_ids.append(task_id2)
 
             self.assertNotEqual(task_id1, task_id2)
             self.assertEqual(len(set(all_task_ids)), 2)
 
-            self._run(self.my_task.delay(a=856324, b=141))
+            self._run(self.my_task.delay(a=856_324, b=141))
             task_id3 = json.loads(mock_enqueue.mock.call_args[1]["item"])["task_options"]["task_id"]
             all_task_ids.append(task_id3)
             self.assertNotEqual(task_id1, task_id3)
             self.assertEqual(len(set(all_task_ids)), 3)
 
-            try:
-                self._run(
-                    self.my_task.retry(
-                        a=856324, b=141, task_options=wiji.task.TaskOptions(max_retries=5)
-                    )
+            self._run(
+                self.my_task.retry(
+                    a=856_324, b=141, task_options=wiji.task.TaskOptions(max_retries=5)
                 )
-            except wiji.task.WijiRetryError:
-                pass
-
+            )
             task_id4 = json.loads(mock_enqueue.mock.call_args[1]["item"])["task_options"]["task_id"]
             all_task_ids.append(task_id4)
             self.assertNotEqual(task_id3, task_id4)
             self.assertEqual(len(set(all_task_ids)), 4)
 
-            try:
-                self._run(
-                    self.my_task.retry(
-                        a=856324, b=141, task_options=wiji.task.TaskOptions(max_retries=5)
-                    )
+            self._run(
+                self.my_task.retry(
+                    a=856_324, b=141, task_options=wiji.task.TaskOptions(max_retries=5)
                 )
-            except wiji.task.WijiRetryError:
-                pass
-
+            )
             task_id5 = json.loads(mock_enqueue.mock.call_args[1]["item"])["task_options"]["task_id"]
             all_task_ids.append(task_id5)
             self.assertNotEqual(task_id3, task_id5)
@@ -227,56 +219,45 @@ class TestTask(TestCase):
     def test_retry(self):
         max_retries = 3
 
-        self._run(self.my_task.delay(a=44, b=252223))
+        self._run(self.my_task.delay(a=44, b=252_223))
         self.assertEqual(self.my_task.current_retries, 0)
         self.assertEqual(self.my_task.max_retries, 0)
 
         # retry_1
-        try:
-            self._run(
-                self.my_task.retry(
-                    a=23, b=1481, task_options=wiji.task.TaskOptions(max_retries=max_retries)
-                )
+        self._run(
+            self.my_task.retry(
+                a=23, b=1481, task_options=wiji.task.TaskOptions(max_retries=max_retries)
             )
-        except wiji.task.WijiRetryError:
-            pass
+        )
         self.assertEqual(self.my_task.current_retries, 1)
         self.assertEqual(self.my_task.max_retries, max_retries)
 
         # retry_2
-        try:
-            self._run(
-                self.my_task.retry(
-                    a=101, b=98, task_options=wiji.task.TaskOptions(max_retries=max_retries)
-                )
+        self._run(
+            self.my_task.retry(
+                a=101, b=98, task_options=wiji.task.TaskOptions(max_retries=max_retries)
             )
-        except wiji.task.WijiRetryError:
-            pass
+        )
         self.assertEqual(self.my_task.current_retries, 2)
         self.assertEqual(self.my_task.max_retries, max_retries)
 
         # retry_3
-        try:
-            self._run(
-                self.my_task.retry(
-                    a=12, b=2, task_options=wiji.task.TaskOptions(max_retries=max_retries)
-                )
+        self._run(
+            self.my_task.retry(
+                a=12, b=2, task_options=wiji.task.TaskOptions(max_retries=max_retries)
             )
-        except wiji.task.WijiRetryError:
-            pass
+        )
+
         self.assertEqual(self.my_task.current_retries, 3)
         self.assertEqual(self.my_task.max_retries, max_retries)
 
         # retry_4
         def retrial_4():
-            try:
-                self._run(
-                    self.my_task.retry(
-                        a=1513, b=783, task_options=wiji.task.TaskOptions(max_retries=max_retries)
-                    )
+            self._run(
+                self.my_task.retry(
+                    a=1513, b=783, task_options=wiji.task.TaskOptions(max_retries=max_retries)
                 )
-            except wiji.task.WijiRetryError:
-                pass
+            )
 
         self.assertRaises(wiji.task.WijiMaxRetriesExceededError, retrial_4)
         with self.assertRaises(wiji.task.WijiMaxRetriesExceededError) as raised_exception:

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -222,6 +222,7 @@ class TestTask(TestCase):
         self._run(self.my_task.delay(a=44, b=252_223))
         self.assertEqual(self.my_task.current_retries, 0)
         self.assertEqual(self.my_task.max_retries, 0)
+        self.assertEqual(self.my_task._RETRYING, False)
 
         # retry_1
         self._run(
@@ -231,6 +232,7 @@ class TestTask(TestCase):
         )
         self.assertEqual(self.my_task.current_retries, 1)
         self.assertEqual(self.my_task.max_retries, max_retries)
+        self.assertEqual(self.my_task._RETRYING, True)
 
         # retry_2
         self._run(
@@ -240,6 +242,7 @@ class TestTask(TestCase):
         )
         self.assertEqual(self.my_task.current_retries, 2)
         self.assertEqual(self.my_task.max_retries, max_retries)
+        self.assertEqual(self.my_task._RETRYING, True)
 
         # retry_3
         self._run(
@@ -250,6 +253,7 @@ class TestTask(TestCase):
 
         self.assertEqual(self.my_task.current_retries, 3)
         self.assertEqual(self.my_task.max_retries, max_retries)
+        self.assertEqual(self.my_task._RETRYING, True)
 
         # retry_4
         def retrial_4():
@@ -266,3 +270,4 @@ class TestTask(TestCase):
             "has reached its max_retries count of: {max_retries}".format(max_retries=max_retries),
             str(raised_exception.exception),
         )
+        self.assertEqual(self.my_task._RETRYING, False)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -346,6 +346,7 @@ class TestWorker(TestCase):
             async def run(self, a, b):
                 res = a + b
                 await self.retry(a=221, b=555, task_options=wiji.task.TaskOptions(max_retries=2))
+                return res
 
         MYAdderTask = AdderTask(
             the_broker=self.BROKER, queue_name="AdderTaskChainQueue", chain=MYDividerTask

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -193,7 +193,7 @@ class TestWorker(TestCase):
             self.assertEqual(mock_task_delay.mock.call_args[1], kwargs)
 
     def test_run_task_called(self):
-        kwargs = {"a": 263342, "b": 832429}
+        kwargs = {"a": 263_342, "b": 832_429}
         with mock.patch("wiji.worker.Worker.run_task", new=AsyncMock()) as mock_run_task:
             worker = wiji.Worker(the_task=self.myTask, worker_id="myWorkerID1")
             self.myTask.synchronous_delay(a=kwargs["a"], b=kwargs["b"])
@@ -205,7 +205,7 @@ class TestWorker(TestCase):
             self.assertEqual(mock_run_task.mock.call_args[1]["b"], kwargs["b"])
 
     def test_broker_done_called(self):
-        kwargs = {"a": 263342, "b": 832429}
+        kwargs = {"a": 263_342, "b": 832_429}
         with mock.patch(
             "{broker_path}.done".format(broker_path=self.broker_path()), new=AsyncMock()
         ) as mock_broker_done:
@@ -318,6 +318,48 @@ class TestWorker(TestCase):
             self.assertEqual(dequeued_item["version"], 1)
             # chain is not queued
             self.assertFalse(mock_task_delay.mock.called)
+
+    def test_no_chaining_if_retrying(self):
+        """
+        test that if parent task is been retried, the chained task is not queued
+        """
+
+        class DividerTask(wiji.task.Task):
+            async def run(self, a):
+                res = a / 3
+                print("divider res: ", res)
+                return res
+
+        MYDividerTask = DividerTask(the_broker=self.BROKER, queue_name="DividerTaskChainQueue")
+
+        class AdderTask(wiji.task.Task):
+            async def run(self, a, b):
+                res = a + b
+                await self.retry(a=221, b=555, task_options=wiji.task.TaskOptions(max_retries=2))
+
+        MYAdderTask = AdderTask(
+            the_broker=self.BROKER, queue_name="AdderTaskChainQueue", chain=MYDividerTask
+        )
+
+        kwargs = {"a": 400, "b": 603}
+        worker = wiji.Worker(the_task=MYAdderTask, worker_id="myWorkerID1")
+        MYAdderTask.synchronous_delay(a=kwargs["a"], b=kwargs["b"])
+
+        with mock.patch.object(
+            AdderTask, "delay", new=AsyncMock()
+        ) as mock_adder_delay, mock.patch.object(
+            DividerTask, "delay", new=AsyncMock()
+        ) as mock_divider_delay:
+            mock_adder_delay.mock.return_value = None
+            mock_divider_delay.return_value = None
+
+            dequeued_item = self._run(worker.consume_tasks(TESTING=True))
+            self.assertEqual(dequeued_item["version"], 1)
+
+            # divider chain is not queued
+            self.assertFalse(mock_divider_delay.mock.called)
+            # but adder task is queued again
+            self.assertTrue(mock_adder_delay.mock.called)
 
     def test_shutdown(self):
         class AdderTask(wiji.task.Task):

--- a/wiji/task.py
+++ b/wiji/task.py
@@ -474,6 +474,7 @@ class Task(abc.ABC):
         self._validate_delay_args(*args, **kwargs)
 
         if self.current_retries >= self.max_retries:
+            self._RETRYING = False
             raise WijiMaxRetriesExceededError(
                 "The task:`{task_name}` has reached its max_retries count of: {max_retries}".format(
                     task_name=self.task_name, max_retries=self.max_retries

--- a/wiji/task.py
+++ b/wiji/task.py
@@ -29,16 +29,6 @@ class WijiMaxRetriesExceededError(Exception):
     pass
 
 
-class WijiRetryError(Exception):
-    """
-    Exception that is raised so that `wiji.Worker` can know that current executing task is retrying.
-    This enables `wiji.Worker` not to schedule any chained tasks of the current executing task.
-    User applications should not capture this Exception!
-    """
-
-    pass
-
-
 class TaskDelayError(Exception):
     """
     raised if `wiji` is unable to publish to the broker for any reason.
@@ -220,7 +210,8 @@ class Task(abc.ABC):
         else:
             self.the_ratelimiter = ratelimiter.SimpleRateLimiter(log_handler=self.logger)
 
-        self._checked_broker = False
+        self._checked_broker: bool = False
+        self._RETRYING: bool = False
 
     async def __call__(self, *args, **kwargs):
         await self.run(*args, **kwargs)
@@ -474,7 +465,6 @@ class Task(abc.ABC):
 
         Raises:
             WijiMaxRetriesExceededError: the task exceeded its max_retries count.
-            WijiRetryError: the task is been retried. User applications should not capture this Exception.
 
         This method takes the same parameters as the `delay` method.
         It also behaves the same as `delay`
@@ -493,11 +483,7 @@ class Task(abc.ABC):
         self.current_retries += 1
         await self.delay(*args, **kwargs)
 
-        raise WijiRetryError(
-            "Task: `{task_name}` is been retried. User applications should not capture this Exception!".format(
-                task_name=self.task_name
-            )
-        )
+        self._RETRYING = True
 
     def _validate_delay_args(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         for a in args:


### PR DESCRIPTION
Thank you for contributing to wiji.                    
Every contribution to wiji is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to wiji, and wiji agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that wiji shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- remove `wiji.task.WijiRetryError`
  We replace it with a `task.Task._RETRYING` boolean.

# Why(Why did you change it?)
- `WijiRetryError` makes it harder to write tests and it also looks like an antipattern
- fixes: https://github.com/komuw/wiji/issues/43

# References:
1. 
