### PR TITLE
rename CLI option, `--config` to `--app`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
             sudo apt -y install pandoc
             sudo pip install -e .[dev,test]
             wiji-cli --version
-            wiji-cli --config tests.testdata.cli.my_app.MyAppInstance --dry-run
+            wiji-cli --app tests.testdata.cli.my_app.MyAppInstance --dry-run
 
   check-releases-notes:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 most recent version is listed first.
 
 ## **version:** v0.1.6-beta.4
-- rename CLI option, `--config` to `--app` 
+- rename CLI option, `--config` to `--app` : https://github.com/komuw/wiji/pull/52
 
 ## **version:** v0.1.6-beta.3
 - bugfix, `task.task_options is stale`    

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## `wiji` changelog:
 most recent version is listed first.
 
+## **version:** v0.1.6-beta.4
+- rename CLI option, `--config` to `--app` 
+
 ## **version:** v0.1.6-beta.3
 - bugfix, `task.task_options is stale`    
   We had a case where `broker.done` would get called with `task_id`==`''`(empty string) : https://github.com/komuw/wiji/pull/39

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ asyncio.run(worker.consume_tasks())
 #### 2. As a cli app
 `wiji` also ships with a commandline app called `wiji-cli`.             
                 
-create a `wiji` config file(which is just any python file that has a class instance of `wiji.app.App`), eg;             
+create a `wiji` app file(which is just any python file that has a class instance of `wiji.app.App`), eg;             
 `examples/my_app.py`                 
 ```python
 import wiji

--- a/README.md
+++ b/README.md
@@ -91,5 +91,5 @@ MyAppInstance = wiji.app.App(task_classes=[AdderTask])
 then run `wiji-cli` pointing it to the dotted path of the `wiji.app.App` instance:     
 
 ```bash
-wiji-cli --config examples.my_app.MyAppInstance
+wiji-cli --app examples.my_app.MyAppInstance
 ```

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -23,7 +23,7 @@ def make_parser() -> argparse.ArgumentParser:
         description="""wiji is an async distributed task queue.
                 example usage:
                 wiji-cli \
-                --config dotted.path.to.a.wiji.app.App.class.instance
+                --app dotted.path.to.a.wiji.app.App.class.instance
                 """,
     )
     parser.add_argument(
@@ -33,10 +33,10 @@ def make_parser() -> argparse.ArgumentParser:
         help="The currently installed wiji version.",
     )
     parser.add_argument(
-        "--config",
+        "--app",
         required=True,
-        help="The config file to use. \
-        eg: --config dotted.path.to.a.wiji.app.App.class.instance",
+        help="The dotted path to a python file conatining a `wiji.app.App` instance. \
+        eg: --app dotted.path.to.a.wiji.app.App.class.instance",
     )
     parser.add_argument(
         "--dry-run",
@@ -53,7 +53,7 @@ def make_parser() -> argparse.ArgumentParser:
 def main():
     """
     run as:
-        wiji-cli --config dotted.path.to.a.wiji.app.App.class.instance
+        wiji-cli --app dotted.path.to.a.wiji.app.App.class.instance
     """
     worker_id = "".join(random.choices(string.ascii_uppercase + string.digits, k=17))
     logger = wiji.logger.SimpleLogger("wiji.cli")
@@ -62,7 +62,7 @@ def main():
         parser = make_parser()
         args = parser.parse_args()
 
-        config = args.config
+        app = args.app
         dry_run = args.dry_run
         if dry_run:
             logger.log(
@@ -72,7 +72,7 @@ def main():
                 ),
             )
 
-        app_instance = utils.load.load_class(config)
+        app_instance = utils.load.load_class(app)
         if not isinstance(app_instance, wiji.app.App):
             err = ValueError(
                 """`app_instance` should be of type:: `wiji.app.App` You entered: {0}""".format(

--- a/examples/my_app.py
+++ b/examples/my_app.py
@@ -14,7 +14,7 @@ class AdderTask(wiji.task.Task):
 
 
 # run cli as:
-#   wiji-cli --config examples.my_app.MyAppInstance
+#   wiji-cli --app examples.my_app.MyAppInstance
 MyAppInstance = wiji.app.App(task_classes=[AdderTask])
 
 

--- a/examples/wiji_app.py
+++ b/examples/wiji_app.py
@@ -12,7 +12,7 @@ from examples.example_tasks import (
 )
 
 # run cli as:
-#   wiji-cli --config examples.wiji_app.yolo
+#   wiji-cli --app examples.wiji_app.yolo
 yolo = wiji.app.App(
     task_classes=[
         BlockingDiskIOTask,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,15 +22,15 @@ def AsyncMock(*args, **kwargs):
 
 
 class MockArgumentParser:
-    def __init__(self, wiji_config, dry_run=True):
-        self.wiji_config = wiji_config
+    def __init__(self, wiji_app, dry_run=True):
+        self.wiji_app = wiji_app
         self.dry_run = dry_run
 
     def add_argument(self, *args, **kwargs):
         pass
 
     def parse_args(self, args=None, namespace=None):
-        return argparse.Namespace(config=self.wiji_config, dry_run=self.dry_run, loglevel="DEBUG")
+        return argparse.Namespace(app=self.wiji_app, dry_run=self.dry_run, loglevel="DEBUG")
 
 
 class TestCli(TestCase):
@@ -43,7 +43,7 @@ class TestCli(TestCase):
 
     def setUp(self):
         self.parser = cli.cli.make_parser()
-        self.wiji_config = "tests.testdata.cli.my_app.MyAppInstance"
+        self.wiji_app = "tests.testdata.cli.my_app.MyAppInstance"
 
     def tearDown(self):
         pass
@@ -54,7 +54,7 @@ class TestCli(TestCase):
 
     def test_cli_success(self):
         with mock.patch("argparse.ArgumentParser") as mock_ArgumentParser:
-            mock_ArgumentParser.return_value = MockArgumentParser(wiji_config=self.wiji_config)
+            mock_ArgumentParser.return_value = MockArgumentParser(wiji_app=self.wiji_app)
             cli.cli.main()
 
 
@@ -107,13 +107,13 @@ class TestCliLoad(TestCase):
     """
 
     def setUp(self):
-        self.wiji_config = "tests.testdata.cli.my_app.MyAppInstance"
+        self.wiji_app = "tests.testdata.cli.my_app.MyAppInstance"
 
     def tearDown(self):
         pass
 
     def test_success(self):
-        app = cli.utils.load.load_class(self.wiji_config)
+        app = cli.utils.load.load_class(self.wiji_app)
         self.assertIsInstance(app, wiji.app.App)
 
     def test_fail(self):

--- a/wiji/__version__.py
+++ b/wiji/__version__.py
@@ -2,7 +2,7 @@ about = {
     "__title__": "wiji",
     "__description__": "Wiji is an asyncio distributed task processor/queue.",
     "__url__": "https://github.com/komuw/wiji",
-    "__version__": "v0.1.6-beta.3",
+    "__version__": "v0.1.6-beta.4",
     "__author__": "komuW",
     "__author_email__": "komuw05@gmail.com",
     "__license__": "MIT",


### PR DESCRIPTION
Thank you for contributing to wiji.                    
Every contribution to wiji is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to wiji, and wiji agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that wiji shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- rename CLI option, `--config` to `--app`

# Why(Why did you change it?)
- fixes: https://github.com/komuw/wiji/issues/51

# References:
1. 
