### PR TITLE
rename TaskDelayError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 most recent version is listed first.
 
 
-## **version:** v0.1.7
-hook and ratelimiter should have access to queuing metrics : https://github.com/komuw/wiji/pull/57
+## **version:** v0.1.8
+- rename `TaskDelayError` to `TaskQueueingError`: https://github.com/komuw/wiji/pull/58
 
+## **version:** v0.1.7
+- hook and ratelimiter should have access to queuing metrics : https://github.com/komuw/wiji/pull/57
 
 ## **version:** v0.1.6
 - add better error messages : https://github.com/komuw/wiji/pull/54

--- a/wiji/__version__.py
+++ b/wiji/__version__.py
@@ -2,7 +2,7 @@ about = {
     "__title__": "wiji",
     "__description__": "Wiji is an asyncio distributed task processor/queue.",
     "__url__": "https://github.com/komuw/wiji",
-    "__version__": "v0.1.7",
+    "__version__": "v0.1.8",
     "__author__": "komuW",
     "__author_email__": "komuw05@gmail.com",
     "__license__": "MIT",

--- a/wiji/task.py
+++ b/wiji/task.py
@@ -690,4 +690,4 @@ class _watchdogTask(Task):
         await asyncio.sleep(0.1 / 1.5)
 
 
-WatchDogTask = _watchdogTask()
+WatchDogTask: _watchdogTask = _watchdogTask()

--- a/wiji/task.py
+++ b/wiji/task.py
@@ -30,7 +30,7 @@ class WijiMaxRetriesExceededError(Exception):
     pass
 
 
-class TaskDelayError(Exception):
+class TaskQueueingError(Exception):
     """
     raised if `wiji` is unable to publish to the broker for any reason.
     """
@@ -548,7 +548,7 @@ class Task(abc.ABC):
                     "error": str(e),
                 },
             )
-            raise TaskDelayError(
+            raise TaskQueueingError(
                 "Task: {0}. publishing to the broker failed.".format(self._debug_task_name)
             ) from e
         finally:


### PR DESCRIPTION
Thank you for contributing to wiji.                    
Every contribution to wiji is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to wiji, and wiji agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that wiji shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- rename `TaskDelayError` to `TaskQueueingError`

# Why(Why did you change it?)
- the new one is more descriptive 

# References:
1. 
