### PR TITLE
issues/60:: change default `Task` loglevel to `INFO` from `DEBUG` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ most recent version is listed first.
 
 
 ## **version:** v0.1.9
-- change default `Task` loglevel to `INFO` from `DEBUG`: 
+- change default `Task` loglevel to `INFO` from `DEBUG`: https://github.com/komuw/wiji/pull/62
 
 ## **version:** v0.1.8
 - rename `TaskDelayError` to `TaskQueueingError`: https://github.com/komuw/wiji/pull/58

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 most recent version is listed first.
 
 
+## **version:** v0.1.9
+- change default `Task` loglevel to `INFO` from `DEBUG`: 
+
 ## **version:** v0.1.8
 - rename `TaskDelayError` to `TaskQueueingError`: https://github.com/komuw/wiji/pull/58
 

--- a/wiji/__version__.py
+++ b/wiji/__version__.py
@@ -2,7 +2,7 @@ about = {
     "__title__": "wiji",
     "__description__": "Wiji is an asyncio distributed task processor/queue.",
     "__url__": "https://github.com/komuw/wiji",
-    "__version__": "v0.1.8",
+    "__version__": "v0.1.9",
     "__author__": "komuW",
     "__author_email__": "komuw05@gmail.com",
     "__license__": "MIT",

--- a/wiji/task.py
+++ b/wiji/task.py
@@ -152,7 +152,7 @@ class Task(abc.ABC):
     # mainly because that is also the default value of the process supervisor: `supervisord`
     drain_duration: float = 10.0
 
-    loglevel: str = "DEBUG"
+    loglevel: str = "INFO"
     log_metadata: typing.Union[None, dict] = None
     log_handler: typing.Union[None, logger.BaseLogger] = None
 


### PR DESCRIPTION
Thank you for contributing to wiji.                    
Every contribution to wiji is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to wiji, and wiji agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that wiji shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- change default `Task` loglevel to `INFO` from `DEBUG`

# Why(Why did you change it?)
- Fixes: https://github.com/komuw/wiji/issues/60

# References:
1. 
