### PR TITLE
issues/61:: fix an ISO 8601 datetime formatting bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ most recent version is listed first.
 
 ## **version:** v0.1.9
 - change default `Task` loglevel to `INFO` from `DEBUG`: https://github.com/komuw/wiji/pull/62
+- bugfix: ISO 8601 datetime formatting: https://github.com/komuw/wiji/pull/63
 
 ## **version:** v0.1.8
 - rename `TaskDelayError` to `TaskQueueingError`: https://github.com/komuw/wiji/pull/58

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,40 @@
+# do not to pollute the global namespace.
+# see: https://python-packaging.readthedocs.io/en/latest/testing.html
+import datetime
+from unittest import TestCase
+
+import wiji
+
+
+class TestProtocol(TestCase):
+    """
+    run tests as:
+        python -m unittest discover -v -s .
+    run one testcase as:
+        python -m unittest -v tests.test_protocol.TestProtocol.test_something
+    """
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_from_isoformat(self):
+        dt = wiji.protocol.Protocol._from_isoformat(eta="2020-04-01T18:41:54.195638+00:00")
+        self.assertEqual(
+            dt, datetime.datetime(2020, 4, 1, 18, 41, 54, 195638, tzinfo=datetime.timezone.utc)
+        )
+
+        # this guards against: https://github.com/komuw/wiji/issues/61
+        dt = wiji.protocol.Protocol._from_isoformat(eta="2019-05-15T14:06:43+00:00")
+        self.assertEqual(
+            dt, datetime.datetime(2019, 5, 15, 14, 6, 43, tzinfo=datetime.timezone.utc)
+        )
+
+    def test_to_isoformat(self):
+        iso_fmt_str = wiji.protocol.Protocol._eta_to_isoformat(0.00)
+        self.assertIsInstance(iso_fmt_str, str)
+
+        iso_fmt_str = wiji.protocol.Protocol._eta_to_isoformat(3.41)
+        self.assertIsInstance(iso_fmt_str, str)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,5 +1,6 @@
 # do not to pollute the global namespace.
 # see: https://python-packaging.readthedocs.io/en/latest/testing.html
+import json
 import datetime
 from unittest import TestCase
 
@@ -38,3 +39,19 @@ class TestProtocol(TestCase):
 
         iso_fmt_str = wiji.protocol.Protocol._eta_to_isoformat(3.41)
         self.assertIsInstance(iso_fmt_str, str)
+
+    def test_eta_conversions(self):
+        """
+        test eta when calling `Task.delay` and `Worker.consume_tasks`
+        """
+        task_options = wiji.task.TaskOptions()
+        proto = wiji.protocol.Protocol(version=1, task_options=task_options)
+        _dequeued_item = proto.json()
+        dequeued_item = json.loads(_dequeued_item)
+        _task_options = dequeued_item["task_options"]
+        task_eta = _task_options["eta"]
+        self.assertEqual(task_eta, task_options.eta)
+        self.assertEqual(
+            wiji.protocol.Protocol._from_isoformat(task_eta),
+            wiji.protocol.Protocol._from_isoformat(task_options.eta),
+        )

--- a/wiji/__init__.py
+++ b/wiji/__init__.py
@@ -5,7 +5,7 @@ from . import hook  # noqa: F401
 from . import app  # noqa: F401
 from . import broker  # noqa: F401
 from . import logger  # noqa: F401
+from . import protocol  # noqa: F401
 from . import ratelimiter  # noqa: F401
-
 
 from . import __version__  # noqa: F401

--- a/wiji/protocol.py
+++ b/wiji/protocol.py
@@ -90,7 +90,7 @@ class Protocol:
         usage:
             dt = Protocol._from_isoformat(eta="2020-04-01T18:41:54.195638+00:00")
         """
-        dt = datetime.datetime.strptime(eta, "%Y-%m-%dT%H:%M:%S.%f%z")
+        dt = datetime.datetime.fromisoformat(eta)
         return dt
 
     def json(self) -> str:

--- a/wiji/protocol.py
+++ b/wiji/protocol.py
@@ -7,16 +7,9 @@ if typing.TYPE_CHECKING:
 
 
 class Protocol:
-    def __init__(self, version: int, task_options: "task.TaskOptions"):
+    def __init__(self, version: int, task_options: "task.TaskOptions") -> None:
         self._validate_protocol_args(version=version, task_options=task_options)
         self.version = version
-
-        if isinstance(task_options.eta, float):
-            eta = self._eta_to_isoformat(eta=task_options.eta)
-        else:
-            eta = task_options.eta
-
-        task_options.eta = eta
         self.task_options = task_options
 
     def _validate_protocol_args(self, version: int, task_options: "task.TaskOptions"):
@@ -34,22 +27,22 @@ class Protocol:
                 )
             )
 
-        if not isinstance(task_options.eta, (str, float)):
+        if not isinstance(task_options.eta, str):
             raise ValueError(
-                """`eta` should be of type:: `str` or `float` You entered: {0}""".format(
+                """`task.TaskOptions.eta` should be of type:: `str` You entered: {0}""".format(
                     type(task_options.eta)
                 )
             )
-        if isinstance(task_options.eta, str):
-            try:
-                # type-check that string eta is ISO 8601-formatted
-                self._from_isoformat(task_options.eta)
-            except Exception as e:
-                raise ValueError(
-                    """`task.TaskOptions.eta` in string format should be a python ISO 8601-formatted string. You entered: {0}""".format(
-                        task_options.eta
-                    )
-                ) from e
+        try:
+            # type-check that string eta is ISO 8601-formatted
+            self._from_isoformat(task_options.eta)
+        except Exception as e:
+            raise ValueError(
+                """`task.TaskOptions.eta` in string format should be a python ISO 8601-formatted string. You entered: {0}""".format(
+                    task_options.eta
+                )
+            ) from e
+
         if not isinstance(task_options.current_retries, int):
             raise ValueError(
                 """`task.TaskOptions.current_retries` should be of type:: `int` You entered: {0}""".format(
@@ -82,7 +75,7 @@ class Protocol:
             )
 
     @staticmethod
-    def _eta_to_isoformat(eta):
+    def _eta_to_isoformat(eta) -> str:
         """
         converts eta in float seconds to python's ISO 8601-formatted datetime.
         """
@@ -91,7 +84,7 @@ class Protocol:
         return eta
 
     @staticmethod
-    def _from_isoformat(eta):
+    def _from_isoformat(eta) -> datetime.datetime:
         """
         converts ISO 8601-formatted datetime to python datetime
         usage:
@@ -100,5 +93,5 @@ class Protocol:
         dt = datetime.datetime.strptime(eta, "%Y-%m-%dT%H:%M:%S.%f%z")
         return dt
 
-    def json(self):
+    def json(self) -> str:
         return json.dumps({"version": self.version, "task_options": self.task_options.dictsy()})

--- a/wiji/task.py
+++ b/wiji/task.py
@@ -515,7 +515,6 @@ class Task(abc.ABC):
         if not self._checked_broker:
             await self._broker_check(from_worker=False)
 
-        proto = protocol.Protocol(version=1, task_options=task_options)
         await self._notify_hook(
             task_id=task_options.task_id,
             state=TaskState.QUEUEING,
@@ -528,6 +527,7 @@ class Task(abc.ABC):
         monotonic_start = time.monotonic()
         process_time_start = time.process_time()
         try:
+            proto = protocol.Protocol(version=1, task_options=task_options)
             await self.the_broker.enqueue(queue_name=self.queue_name, item=proto.json())
         except TypeError as e:
             self._log(logging.ERROR, {"event": "wiji.Task.delay", "stage": "end", "error": str(e)})

--- a/wiji/task.py
+++ b/wiji/task.py
@@ -62,11 +62,10 @@ class TaskOptions:
         self._validate_task_options_args(
             eta=eta, max_retries=max_retries, hook_metadata=hook_metadata
         )
-        self.eta = eta
-        if self.eta < 0.00:
-            self.eta = 0.00
+        if eta < 0.00:
+            eta = 0.00
+        self.eta = protocol.Protocol._eta_to_isoformat(eta=eta)
         self.task_id = ""
-
         self.current_retries: int = 0
         self.max_retries = max_retries
         if self.max_retries < 0:


### PR DESCRIPTION
Thank you for contributing to wiji.                    
Every contribution to wiji is important.                       

                     

Contributor offers to license certain software (a “Contribution” or multiple
“Contributions”) to wiji, and wiji agrees to accept said Contributions,
under the terms of the MIT License.
Contributor understands and agrees that wiji shall have the irrevocable and perpetual right to make
and distribute copies of any Contribution, as well as to create and distribute collective works and
derivative works of any Contribution, under the MIT License.


Now,                   

# What(What have you changed?)
- Use `datetime.datetime.fromisoformat(eta)` for ISO 8601 datetime formatting

# Why(Why did you change it?)
- fix an ISO 8601 datetime formatting bug
- Fixes: https://github.com/komuw/wiji/issues/61

# References:
1. 
